### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/dls-controls/hdf5filters.svg?branch=master)](https://travis-ci.org/dls-controls/hdf5filters)
+[![Build Status](https://travis-ci.org/DiamondLightSource/hdf5filters.svg?branch=master)](https://travis-ci.org/DiamondLightSource/hdf5filters)
 
 hdf5filters
 ===========


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/hdf5filters` using https://gitlab.diamond.ac.uk/github/github-scripts